### PR TITLE
fix: require admin auth for PPCActivator.py polkit action

### DIFF
--- a/polkit/tr.org.pardus.pkexec.parental-control.policy
+++ b/polkit/tr.org.pardus.pkexec.parental-control.policy
@@ -13,9 +13,9 @@
     <icon_name>preferences-system</icon_name>
 
     <defaults>
-      <allow_any>yes</allow_any>
-      <allow_inactive>yes</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
 
     <annotate key="org.freedesktop.policykit.exec.path">/usr/share/pardus/pardus-parental-control/src/PPCActivator.py</annotate>


### PR DESCRIPTION
## Summary

- `parental-control-action` polkit policy has `<allow_any>yes</allow_any>`, allowing any local user (including the restricted child account) to run `PPCActivator.py --disable` as root without authentication
- Changed policy to `auth_admin` / `auth_admin_keep` — matching the existing policy for `system_preferences_changer.py`

## Vulnerability

```bash
# As kid (restricted child account), no password prompted:
pkexec /usr/share/pardus/pardus-parental-control/src/PPCActivator.py --disable
# uid=0 euid=0 pkexec_uid=1000 → all filters removed
```

## PoC Environment

```bash
docker run -d --name pardus-poc --privileged debian:bookworm sleep infinity
# After installing polkit + pardus-parental-control:
su - kid -c "pkexec .../PPCActivator.py --disable"
# Result: exit 0, no password, ran as root
```

## Change

| Field | Before | After |
|-------|--------|-------|
| `allow_any` | `yes` | `auth_admin` |
| `allow_inactive` | `yes` | `auth_admin` |
| `allow_active` | `yes` | `auth_admin_keep` |

`parental-control-action-logout` (session_logger.py) is unchanged — it is invoked automatically by the system at login, requiring auth would break session tracking.